### PR TITLE
Install new product id certificates during upgrade

### DIFF
--- a/85system-upgrade-redhat/do-upgrade.sh
+++ b/85system-upgrade-redhat/do-upgrade.sh
@@ -27,7 +27,10 @@ do_upgrade() {
     $UPGRADEBIN --root=/sysroot $args
     rv=$?
 
-    # install new product id certificates (override existing)
+    # backup old product id certificates
+    chroot $NEWROOT /bin/sh -c 'mkdir /etc/pki/product_old; mv -f /etc/pki/product/*.pem /etc/pki/product_old/'
+
+    # install new product id certificates
     chroot $NEWROOT /bin/sh -c 'mv -f /system-upgrade/*.pem /etc/pki/product/'
 
     # restore things twiddled by workarounds above. TODO: remove!

--- a/85system-upgrade-redhat/do-upgrade.sh
+++ b/85system-upgrade-redhat/do-upgrade.sh
@@ -27,6 +27,9 @@ do_upgrade() {
     $UPGRADEBIN --root=/sysroot $args
     rv=$?
 
+    # install new product id certificates (override existing)
+    chroot $NEWROOT /bin/sh -c 'mv -f /system-upgrade/*.pem /etc/pki/product/'
+
     # restore things twiddled by workarounds above. TODO: remove!
     if [ -f /sys/fs/selinux/enforce ]; then
         echo $enforce > /sys/fs/selinux/enforce


### PR DESCRIPTION
Hi David,
this is the second step of installing RHSM product id certificates (previously downloaded by redhat-upgrade-tool).
