### PR TITLE
Remove old db indexes just before running the upgrade

### DIFF
--- a/85system-upgrade-redhat/do-upgrade.sh
+++ b/85system-upgrade-redhat/do-upgrade.sh
@@ -23,6 +23,8 @@ do_upgrade() {
     # https://bugzilla.redhat.com/show_bug.cgi?id=844167
     # others to be filed (mysterious initramfs without kernel modules, etc.)
 
+    rm -f /sysroot/var/lib/rpm/__db*
+
     # and off we go...
     $UPGRADEBIN --root=/sysroot $args
     rv=$?


### PR DESCRIPTION
When testing an upgrade of a customized RHEL6 to RHEL7, sometimes we see that upgrade fails with a ton of messaged like this:

```
  building RPM transaction, one moment...
  error: db5 error(-30969) from dbenv->open: BDB0091 DB_VERSION_MISMATCH: Database environment version mismatch
  error: cannot open Packages index using db5 -  (-30969)
  error: cannot open Packages database in /sysroot/var/lib/rpm
  Warning: failed to add <some_pkg_name> to the transaction
  Warning: couldn't add <some_pkg_name> to the transaction
```

Can't say for sure which change in the system causes this bug; sometime upgrade works fine, sometimes it fails in almost the same configuration.

There are some reports in the net concerning this issue that recommend to remove __db* indexes in such situations (e.g., https://bugzilla.redhat.com/show_bug.cgi?id=916408#c6).

And indeed, forcing removal of these indexes in do-upgrade.sh seem to completely eliminate the problem in our cases.

